### PR TITLE
future proof deps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,8 +81,8 @@ def get_sdist_config():
         },
         # Application dependencies, pinned:
         install_requires=[
-            'docopt==0.6.1',
-            'blessings==1.6',
+            'docopt>=0.6.1',
+            'blessings>=1.6',
         ],
         packages=find_packages(exclude=['*.tests']),
         #include_package_data=True,


### PR DESCRIPTION
package fails running on Arch Linux due to specifying outdated deps

would be nice if you can tag a new release with this version so it can be reflected in downstream packages.

cool program btw!