### PR TITLE
Added Colorama and Windows support

### DIFF
--- a/cbeams/__init__.py
+++ b/cbeams/__init__.py
@@ -16,7 +16,7 @@ Options:
 For details, see the README file.
 '''
 
-__version__ = '1.0.3'
+__version__ = '1.0.4'
 
 __doc__ = __doc__.format(version=__version__)
 

--- a/cbeams/terminal.py
+++ b/cbeams/terminal.py
@@ -2,8 +2,10 @@ import contextlib
 import sys
 import random
 
-from blessings import Terminal
+from colorama import init
+init()
 
+from blessings import Terminal
 terminal = Terminal()
 
 @contextlib.contextmanager

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,7 @@ def get_sdist_config():
         install_requires=[
             'docopt>=0.6.1',
             'blessings>=1.6',
+            'colorama>=0.4.4'
         ],
         packages=find_packages(exclude=['*.tests']),
         #include_package_data=True,


### PR DESCRIPTION
Colorama should now check all Blessings color codes and replace them with Windows equivalents.